### PR TITLE
Change Followings to Following

### DIFF
--- a/src/components/FollowingsList/index.js
+++ b/src/components/FollowingsList/index.js
@@ -19,7 +19,7 @@ function FollowingsList({
 }) {
   return (
     <List
-      title="Followings"
+      title="Following"
       ids={followings}
       entities={userEntities}
       nextHref={nextHref}


### PR DESCRIPTION
`Followings` isn't a word, so don't show that in the UI. The terminology in the code might need to be updated as well, but thats up to you. ¯\\_(ツ)_/¯

https://www.englishforums.com/English/FollowingOrFollowings/cngrh/post.htm

![image](https://cloud.githubusercontent.com/assets/1275831/20649927/09c9d174-b490-11e6-85a2-004eaf5830bd.png)

https://soundcloud.com/yungsqrl/following