### PR TITLE
Fix some playlist item text issues

### DIFF
--- a/src/components/Permalink/index.js
+++ b/src/components/Permalink/index.js
@@ -1,8 +1,8 @@
 import React from 'react';
 
-function Permalink({ link, text }) {
+function Permalink({ link, text, title }) {
   return (
-    <a href={link}>
+    <a href={link} title={title}>
       {text}
     </a>
   );
@@ -10,7 +10,8 @@ function Permalink({ link, text }) {
 
 Permalink.propTypes = {
   link: React.PropTypes.string,
-  text: React.PropTypes.string
+  text: React.PropTypes.string,
+  title: React.PropTypes.string,
 };
 
 export default Permalink;

--- a/src/components/Track/playlist.js
+++ b/src/components/Track/playlist.js
@@ -16,6 +16,7 @@ function TrackPlaylist({
 
   const { user, title, permalink_url, artwork_url } = activity;
   const { avatar_url, username } = userEntities[user];
+  const userPermalinkUrl = userEntities[user].permalink_url;
 
   const trackIsPlaying = isSameTrackAndPlaying(activeTrackId, activity.id, isPlaying);
   const isVisible = isSameTrack(activeTrackId)(activity.id);
@@ -37,7 +38,8 @@ function TrackPlaylist({
         <Artwork image={artwork_url} title={title} optionalImage={avatar_url} size={40} />
       </div>
       <div className="playlist-track-content">
-        <Permalink link={permalink_url} text={username + ' - ' + title} />
+        <Permalink link={permalink_url} text={title} title={title}/>
+        <Permalink link={userPermalinkUrl} text={'by: ' + username} title={username}/>
         <Actions configuration={configuration} isVisible={isVisible} />
       </div>
     </div>

--- a/styles/components/playlist.scss
+++ b/styles/components/playlist.scss
@@ -28,7 +28,6 @@
     height: $padding;
     padding: $padding / 2;
     border-bottom: $darkBorder;
-
     font-size: $menuSize;
   }
 }

--- a/styles/components/playlistTrack.scss
+++ b/styles/components/playlistTrack.scss
@@ -19,7 +19,11 @@
 
     a {
       float: left;
-      width: $padding * 14;
+      width: $padding * 13;
+      display: inline-block;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
     }
   }
 


### PR DESCRIPTION
1. Fix playlist item text overflow issue
2. Reformat the username and text
3. Add title option to permalink

I did these changes mainly because sometimes the text of a playlist item could be too long to fit, and I also seperate the title and username of the sound track into two lines for better readability and accessibility.

Before: 
<img width="872" alt="screen shot 2017-02-15 at 10 07 30 pm" src="https://cloud.githubusercontent.com/assets/15867071/23009519/3d679ca8-f3cb-11e6-8c28-9a0efe38a174.png">

After: 
<img width="793" alt="screen shot 2017-02-15 at 10 08 33 pm" src="https://cloud.githubusercontent.com/assets/15867071/23009537/64720b80-f3cb-11e6-9756-677c6889a28a.png">

You can reveal long text by hovering the mouse over it like this: 
<img width="431" alt="screen shot 2017-02-15 at 10 10 25 pm" src="https://cloud.githubusercontent.com/assets/15867071/23009566/93e7f5d2-f3cb-11e6-8b5e-6b0b27eba760.png">
