### PR TITLE
Fix the track count and playlist button display issue

### DIFF
--- a/src/components/Permalink/index.js
+++ b/src/components/Permalink/index.js
@@ -11,7 +11,7 @@ function Permalink({ link, text, title }) {
 Permalink.propTypes = {
   link: React.PropTypes.string,
   text: React.PropTypes.string,
-  title: React.PropTypes.string,
+  title: React.PropTypes.string
 };
 
 export default Permalink;

--- a/styles/components/buttonInline.scss
+++ b/styles/components/buttonInline.scss
@@ -7,6 +7,7 @@
   padding: 0;
   font-size: inherit;
   cursor: pointer;
+  white-space:nowrap;
 
   &:focus {
     background: transparent;


### PR DESCRIPTION
The playlist button and number of tracks in playlist would be displayed into two separate lines when the number gets bigger. It maybe more consistent if we just keep them in the same line.