### PR TITLE
Fix npm start errors when using npm 7.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "imports-loader": "0.6.5",
     "jsdom": "9.8.3",
     "mocha": "3.1.2",
-    "node-sass": "3.4.2",
+    "node-sass": "3.8.0",
     "react-addons-test-utils": "15.4.0",
     "react-hot-loader": "3.0.0-beta.6",
     "sass-loader": "4.0.2",


### PR DESCRIPTION
A quick fix for errors when running npm start and cpp warnings when running npm install caused by node-sass version. 