### PR TITLE
Fix volume slider does not close when the player closes, #30

### DIFF
--- a/src/actions/player/index.js
+++ b/src/actions/player/index.js
@@ -62,6 +62,7 @@ export const clearPlaylist = () => (dispatch) => {
   dispatch(emptyPlaylist());
   dispatch(deactivateTrack());
   dispatch(resetToggle(toggleTypes.PLAYLIST));
+  dispatch(resetToggle(toggleTypes.VOLUME));
 };
 
 function isInPlaylist(playlist, trackId) {


### PR DESCRIPTION
Fixed the volume slider does not close when the player closes. 