### PR TITLE
Migrate React.PropTypes to prop-types package for React 15.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "lodash": "4.17.4",
     "moment": "2.18.1",
     "normalizr": "2.0.0",
+    "prop-types": "^15.5.10",
     "react": "15.5.4",
     "react-clipboard.js": "1.1.2",
     "react-dom": "15.5.4",

--- a/src/components/Activities/index.js
+++ b/src/components/Activities/index.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import map from '../../services/map';
 import filter from 'lodash/fp/filter';
@@ -47,10 +48,10 @@ function Activities({
 }
 
 Activities.propTypes = {
-  ids: React.PropTypes.array,
-  entities: React.PropTypes.object,
-  activeFilter: React.PropTypes.func,
-  activeSort: React.PropTypes.func,
+  ids: PropTypes.array,
+  entities: PropTypes.object,
+  activeFilter: PropTypes.func,
+  activeSort: PropTypes.func,
 };
 
 export default withLoadingSpinner(withFetchOnScroll(Activities));

--- a/src/components/Artwork/index.js
+++ b/src/components/Artwork/index.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 
 function Artwork({ image, title, optionalImage, size }) {
@@ -5,10 +6,10 @@ function Artwork({ image, title, optionalImage, size }) {
 }
 
 Artwork.propTypes = {
-  image: React.PropTypes.string,
-  title: React.PropTypes.string,
-  optionalImage: React.PropTypes.string,
-  size: React.PropTypes.number
+  image: PropTypes.string,
+  title: PropTypes.string,
+  optionalImage: PropTypes.string,
+  size: PropTypes.number
 };
 
 export default Artwork;

--- a/src/components/ArtworkAction/index.js
+++ b/src/components/ArtworkAction/index.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
 
@@ -20,10 +21,10 @@ function ArtworkAction({ action, isVisible, className, children }) {
 }
 
 ArtworkAction.propTypes = {
-  action: React.PropTypes.func,
-  isVisible: React.PropTypes.bool,
-  className: React.PropTypes.string,
-  children: React.PropTypes.object,
+  action: PropTypes.func,
+  isVisible: PropTypes.bool,
+  className: PropTypes.string,
+  children: PropTypes.object,
 };
 
 export default ArtworkAction;

--- a/src/components/Browse/index.js
+++ b/src/components/Browse/index.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
@@ -86,13 +87,13 @@ function mapDispatchToProps(dispatch) {
 }
 
 Browse.propTypes = {
-  genre: React.PropTypes.string,
-  browseActivities: React.PropTypes.object,
-  requestsInProcess: React.PropTypes.object,
-  paginateLinks: React.PropTypes.object,
-  trackEntities: React.PropTypes.object,
-  userEntities: React.PropTypes.object,
-  fetchActivitiesByGenre: React.PropTypes.func
+  genre: PropTypes.string,
+  browseActivities: PropTypes.object,
+  requestsInProcess: PropTypes.object,
+  paginateLinks: PropTypes.object,
+  trackEntities: PropTypes.object,
+  userEntities: PropTypes.object,
+  fetchActivitiesByGenre: PropTypes.func
 };
 
 Browse.defaultProps = {

--- a/src/components/CommentExtension/index.js
+++ b/src/components/CommentExtension/index.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
@@ -70,13 +71,13 @@ function mapDispatchToProps(dispatch) {
 }
 
 CommentExtension.propTypes = {
-  onFetchComments: React.PropTypes.func,
-  activity: React.PropTypes.object,
-  commentIds: React.PropTypes.array,
-  commentEntities: React.PropTypes.object,
-  userEntities: React.PropTypes.object,
-  requestInProcess: React.PropTypes.bool,
-  nextHref: React.PropTypes.string,
+  onFetchComments: PropTypes.func,
+  activity: PropTypes.object,
+  commentIds: PropTypes.array,
+  commentEntities: PropTypes.object,
+  userEntities: PropTypes.object,
+  requestInProcess: PropTypes.bool,
+  nextHref: PropTypes.string,
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(CommentExtension);

--- a/src/components/FavoritesList/index.js
+++ b/src/components/FavoritesList/index.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
@@ -56,14 +57,14 @@ function mapDispatchToProps(dispatch) {
 }
 
 FavoritesList.propTypes = {
-  currentUser: React.PropTypes.object,
-  trackEntities: React.PropTypes.object,
-  favorites: React.PropTypes.array,
-  requestsInProcess: React.PropTypes.object,
-  paginateLinks: React.PropTypes.object,
-  toggle: React.PropTypes.object,
-  onSetToggle: React.PropTypes.func,
-  onFetchFavorites: React.PropTypes.func
+  currentUser: PropTypes.object,
+  trackEntities: PropTypes.object,
+  favorites: PropTypes.array,
+  requestsInProcess: PropTypes.object,
+  paginateLinks: PropTypes.object,
+  toggle: PropTypes.object,
+  onSetToggle: PropTypes.func,
+  onFetchFavorites: PropTypes.func
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(FavoritesList);

--- a/src/components/FilterDuration/index.js
+++ b/src/components/FilterDuration/index.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import map from '../../services/map';
 import classNames from 'classnames';
@@ -62,8 +63,8 @@ function mapDispatchToProps(dispatch) {
 }
 
 FilterDuration.propTypes = {
-  activeDurationFilter: React.PropTypes.string,
-  onDurationFilter: React.PropTypes.func
+  activeDurationFilter: PropTypes.string,
+  onDurationFilter: PropTypes.func
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(FilterDuration);

--- a/src/components/FilterName/index.js
+++ b/src/components/FilterName/index.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
@@ -48,8 +49,8 @@ function mapDispatchToProps(dispatch) {
 }
 
 FilterName.propTypes = {
-  filterNameQuery: React.PropTypes.string,
-  onNameFilter: React.PropTypes.func
+  filterNameQuery: PropTypes.string,
+  onNameFilter: PropTypes.func
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(FilterName);

--- a/src/components/FollowersList/index.js
+++ b/src/components/FollowersList/index.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
@@ -56,14 +57,14 @@ function mapDispatchToProps(dispatch) {
 }
 
 FollowersList.propTypes = {
-  currentUser: React.PropTypes.object,
-  userEntities: React.PropTypes.object,
-  followers: React.PropTypes.array,
-  requestsInProcess: React.PropTypes.object,
-  paginateLinks: React.PropTypes.object,
-  toggle: React.PropTypes.object,
-  onSetToggle: React.PropTypes.func,
-  onFetchFollowers: React.PropTypes.func
+  currentUser: PropTypes.object,
+  userEntities: PropTypes.object,
+  followers: PropTypes.array,
+  requestsInProcess: PropTypes.object,
+  paginateLinks: PropTypes.object,
+  toggle: PropTypes.object,
+  onSetToggle: PropTypes.func,
+  onFetchFollowers: PropTypes.func
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(FollowersList);

--- a/src/components/FollowingsList/index.js
+++ b/src/components/FollowingsList/index.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
@@ -56,14 +57,14 @@ function mapDispatchToProps(dispatch) {
 }
 
 FollowingsList.propTypes = {
-  currentUser: React.PropTypes.object,
-  userEntities: React.PropTypes.object,
-  followings: React.PropTypes.array,
-  requestsInProcess: React.PropTypes.object,
-  paginateLinks: React.PropTypes.object,
-  toggle: React.PropTypes.object,
-  onSetToggle: React.PropTypes.func,
-  onFetchFollowings: React.PropTypes.func
+  currentUser: PropTypes.object,
+  userEntities: PropTypes.object,
+  followings: PropTypes.array,
+  requestsInProcess: PropTypes.object,
+  paginateLinks: PropTypes.object,
+  toggle: PropTypes.object,
+  onSetToggle: PropTypes.func,
+  onFetchFollowings: PropTypes.func
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(FollowingsList);

--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import map from '../../services/map';
 import classNames from 'classnames';
@@ -102,11 +103,11 @@ function mapDispatchToProps(dispatch) {
 }
 
 Header.propTypes = {
-  currentUser: React.PropTypes.object,
-  genre: React.PropTypes.string,
-  pathname: React.PropTypes.string,
-  onLogin: React.PropTypes.func,
-  onLogout: React.PropTypes.func,
+  currentUser: PropTypes.object,
+  genre: PropTypes.string,
+  pathname: PropTypes.string,
+  onLogin: PropTypes.func,
+  onLogout: PropTypes.func,
 };
 
 Header.defaultProps = {

--- a/src/components/HoverActions/index.js
+++ b/src/components/HoverActions/index.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import map from '../../services/map';
 import classNames from 'classnames';
@@ -31,8 +32,8 @@ function Actions({ configuration, isVisible }) {
 }
 
 Actions.propTypes = {
-  configuration: React.PropTypes.array,
-  isVisible: React.PropTypes.bool
+  configuration: PropTypes.array,
+  isVisible: PropTypes.bool
 };
 
 export default Actions;

--- a/src/components/InfoList/index.js
+++ b/src/components/InfoList/index.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
 import map from '../../services/map';
@@ -28,7 +29,7 @@ function InfoList({ information }) {
 }
 
 InfoList.propTypes = {
-  information: React.PropTypes.array
+  information: PropTypes.array
 };
 
 export default InfoList;

--- a/src/components/List/index.js
+++ b/src/components/List/index.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import map from '../../services/map';
 import classNames from 'classnames';
@@ -102,15 +103,15 @@ function List({
 }
 
 List.propTypes = {
-  ids: React.PropTypes.array,
-  isExpanded: React.PropTypes.bool,
-  title: React.PropTypes.string,
-  kind: React.PropTypes.string,
-  requestInProcess: React.PropTypes.bool,
-  entities: React.PropTypes.object,
-  nextHref: React.PropTypes.string,
-  onToggleMore: React.PropTypes.func,
-  onFetchMore: React.PropTypes.func
+  ids: PropTypes.array,
+  isExpanded: PropTypes.bool,
+  title: PropTypes.string,
+  kind: PropTypes.string,
+  requestInProcess: PropTypes.bool,
+  entities: PropTypes.object,
+  nextHref: PropTypes.string,
+  onToggleMore: PropTypes.func,
+  onFetchMore: PropTypes.func
 };
 
 export default List;

--- a/src/components/LoadingSpinner/index.js
+++ b/src/components/LoadingSpinner/index.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 
 function LoadingSpinner({ isLoading }) {
@@ -11,7 +12,7 @@ function LoadingSpinner({ isLoading }) {
 }
 
 LoadingSpinner.propTypes = {
-  isLoading: React.PropTypes.bool
+  isLoading: PropTypes.bool
 };
 
 export default LoadingSpinner;

--- a/src/components/Permalink/index.js
+++ b/src/components/Permalink/index.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 
 function Permalink({ link, text, title }) {
@@ -9,9 +10,9 @@ function Permalink({ link, text, title }) {
 }
 
 Permalink.propTypes = {
-  link: React.PropTypes.string,
-  text: React.PropTypes.string,
-  title: React.PropTypes.string
+  link: PropTypes.string,
+  text: PropTypes.string,
+  title: PropTypes.string
 };
 
 export default Permalink;

--- a/src/components/Player/index.js
+++ b/src/components/Player/index.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import classNames from 'classnames';
@@ -98,6 +99,8 @@ class Player extends React.Component {
 
     const track = entities.tracks[activeTrackId];
     const { user, title, stream_url } = track;
+
+    // console.log(addAccessTokenWith(stream_url, '?'));
     const { username } = entities.users[user];
 
     const isMuted = !volume;
@@ -238,18 +241,18 @@ function mapDispatchToProps(dispatch) {
 }
 
 Player.propTypes = {
-  currentUser: React.PropTypes.object,
-  activeTrackId: React.PropTypes.number,
-  isPlaying: React.PropTypes.bool,
-  entities: React.PropTypes.object,
-  playlist: React.PropTypes.array,
-  onTogglePlayTrack: React.PropTypes.func,
-  onSetToggle: React.PropTypes.func,
-  onActivateIteratedTrack: React.PropTypes.func,
-  onLike: React.PropTypes.func,
-  onSetShuffleMode: React.PropTypes.func,
-  isInShuffleMode: React.PropTypes.bool,
-  handleTimeUpdate: React.PropTypes.func,
+  currentUser: PropTypes.object,
+  activeTrackId: PropTypes.number,
+  isPlaying: PropTypes.bool,
+  entities: PropTypes.object,
+  playlist: PropTypes.array,
+  onTogglePlayTrack: PropTypes.func,
+  onSetToggle: PropTypes.func,
+  onActivateIteratedTrack: PropTypes.func,
+  onLike: PropTypes.func,
+  onSetShuffleMode: PropTypes.func,
+  isInShuffleMode: PropTypes.bool,
+  handleTimeUpdate: PropTypes.func,
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(Player);

--- a/src/components/Playlist/index.js
+++ b/src/components/Playlist/index.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import map from '../../services/map';
 import classNames from 'classnames';
@@ -64,10 +65,10 @@ function mapDispatchToProps(dispatch) {
 }
 
 Playlist.propTypes = {
-  toggle: React.PropTypes.object,
-  playlist: React.PropTypes.array,
-  trackEntities: React.PropTypes.object,
-  onClearPlaylist: React.PropTypes.func
+  toggle: PropTypes.object,
+  playlist: PropTypes.array,
+  trackEntities: PropTypes.object,
+  onClearPlaylist: PropTypes.func
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(Playlist);

--- a/src/components/Sort/index.js
+++ b/src/components/Sort/index.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import map from '../../services/map';
 import classNames from 'classnames';
@@ -61,8 +62,8 @@ function mapDispatchToProps(dispatch) {
 }
 
 Sort.propTypes = {
-  activeSort: React.PropTypes.string,
-  onSort: React.PropTypes.func
+  activeSort: PropTypes.string,
+  onSort: PropTypes.func
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(Sort);

--- a/src/components/StreamActivities/index.js
+++ b/src/components/StreamActivities/index.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
@@ -60,13 +61,13 @@ function mapDispatchToProps(dispatch) {
 }
 
 StreamActivities.propTypes = {
-  trackEntities: React.PropTypes.object,
-  activities: React.PropTypes.array,
-  requestInProcess: React.PropTypes.bool,
-  nextHref: React.PropTypes.string,
-  activeFilter: React.PropTypes.func,
-  activeSort: React.PropTypes.func,
-  onFetchActivities: React.PropTypes.func,
+  trackEntities: PropTypes.object,
+  activities: PropTypes.array,
+  requestInProcess: PropTypes.bool,
+  nextHref: PropTypes.string,
+  activeFilter: PropTypes.func,
+  activeSort: PropTypes.func,
+  onFetchActivities: PropTypes.func,
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(StreamActivities);

--- a/src/components/Track/playlist.js
+++ b/src/components/Track/playlist.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import Artwork from '../../components/Artwork';
 import Permalink from '../../components/Permalink';
@@ -47,12 +48,12 @@ function TrackPlaylist({
 }
 
 TrackPlaylist.propTypes = {
-  activity: React.PropTypes.object,
-  userEntities: React.PropTypes.object,
-  isPlaying: React.PropTypes.bool,
-  activeTrackId: React.PropTypes.number,
-  onActivateTrack: React.PropTypes.func,
-  onRemoveTrackFromPlaylist: React.PropTypes.func
+  activity: PropTypes.object,
+  userEntities: PropTypes.object,
+  isPlaying: PropTypes.bool,
+  activeTrackId: PropTypes.number,
+  onActivateTrack: PropTypes.func,
+  onRemoveTrackFromPlaylist: PropTypes.func
 };
 
 export {

--- a/src/components/Track/preview.js
+++ b/src/components/Track/preview.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import Artwork from '../../components/Artwork';
 import Permalink from '../../components/Permalink';
@@ -60,12 +61,12 @@ function TrackPreview({
 }
 
 TrackPreview.propTypes = {
-  userEntities: React.PropTypes.object,
-  activity: React.PropTypes.object,
-  isPlaying: React.PropTypes.bool,
-  activeTrackId: React.PropTypes.number,
-  onActivateTrack: React.PropTypes.func,
-  onAddTrackToPlaylist: React.PropTypes.func
+  userEntities: PropTypes.object,
+  activity: PropTypes.object,
+  isPlaying: PropTypes.bool,
+  activeTrackId: PropTypes.number,
+  onActivateTrack: PropTypes.func,
+  onAddTrackToPlaylist: PropTypes.func
 };
 
 export {

--- a/src/components/Track/stream.js
+++ b/src/components/Track/stream.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
 import * as sortTypes from '../../constants/sortTypes';
@@ -145,16 +146,16 @@ function RepostIcon({ repostCount }) {
 }
 
 TrackStream.propTypes = {
-  userEntities: React.PropTypes.object,
-  typeReposts: React.PropTypes.object,
-  typeTracks: React.PropTypes.object,
-  activity: React.PropTypes.object,
-  isPlaying: React.PropTypes.bool,
-  activeTrackId: React.PropTypes.number,
-  idx: React.PropTypes.number,
-  activeSortType: React.PropTypes.string,
-  activeDurationFilterType: React.PropTypes.string,
-  onActivateTrack: React.PropTypes.func,
+  userEntities: PropTypes.object,
+  typeReposts: PropTypes.object,
+  typeTracks: PropTypes.object,
+  activity: PropTypes.object,
+  isPlaying: PropTypes.bool,
+  activeTrackId: PropTypes.number,
+  idx: PropTypes.number,
+  activeSortType: PropTypes.string,
+  activeDurationFilterType: PropTypes.string,
+  onActivateTrack: PropTypes.func,
 };
 
 export {

--- a/src/components/TrackActions/index.js
+++ b/src/components/TrackActions/index.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
@@ -38,8 +39,8 @@ function mapDispatchToProps(dispatch, props) {
 }
 
 TrackActions.propTypes = {
-  onOpenComments: React.PropTypes.func,
-  onAddTrackToPlaylist: React.PropTypes.func,
+  onOpenComments: PropTypes.func,
+  onAddTrackToPlaylist: PropTypes.func,
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(TrackActions);

--- a/src/components/TrackExtension/index.js
+++ b/src/components/TrackExtension/index.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
@@ -23,8 +24,8 @@ function mapDispatchToProps(dispatch) {
 }
 
 TrackExtension.propTypes = {
-  activity: React.PropTypes.object,
-  openComments: React.PropTypes.func,
+  activity: PropTypes.object,
+  openComments: PropTypes.func,
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(TrackExtension);

--- a/src/components/User/preview.js
+++ b/src/components/User/preview.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import find from 'lodash/fp/find';
 import InfoList from '../../components/InfoList';
@@ -45,9 +46,9 @@ function UserPreview({ user, followings, onFollow }) {
 }
 
 UserPreview.propTypes = {
-  followings: React.PropTypes.array,
-  user: React.PropTypes.object,
-  onFollow: React.PropTypes.func
+  followings: PropTypes.array,
+  user: PropTypes.object,
+  onFollow: PropTypes.func
 };
 
 export {

--- a/src/components/Volume/index.js
+++ b/src/components/Volume/index.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
@@ -71,9 +72,9 @@ function mapDispatchToProps(dispatch) {
 }
 
 Volume.propTypes = {
-  onChangeVolume: React.PropTypes.func,
-  volume: React.PropTypes.number,
-  toggle: React.PropTypes.object
+  onChangeVolume: PropTypes.func,
+  volume: PropTypes.number,
+  toggle: PropTypes.object
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(Volume);

--- a/src/components/WaveformSc/index.js
+++ b/src/components/WaveformSc/index.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import Waveform from 'waveform.js';
 import { normalizeSamples, isJsonWaveform, isPngWaveform } from '../../services/track';
@@ -60,8 +61,8 @@ class WaveformSc extends React.Component {
 }
 
 WaveformSc.propTypes = {
-  activity: React.PropTypes.object,
-  idx: React.PropTypes.number
+  activity: PropTypes.object,
+  idx: PropTypes.number
 };
 
 export default WaveformSc;

--- a/src/components/withFetchOnScroll/index.js
+++ b/src/components/withFetchOnScroll/index.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 
 function withFetchOnScroll(Component) {
@@ -27,7 +28,7 @@ function withFetchOnScroll(Component) {
   }
 
   FetchOnScroll.propTypes = {
-    scrollFunction: React.PropTypes.func.isRequired,
+    scrollFunction: PropTypes.func.isRequired,
   };
 
   return FetchOnScroll;


### PR DESCRIPTION
I have gone ahead and migrate React.PropTypes to import from "prop-types" package, but there are still warnings from third-party React libraries like react-tooltips, so I guess we just leave it that way for now until they migrate too. 