### PR TITLE
Fixed issue #51

### DIFF
--- a/src/components/Player/index.js
+++ b/src/components/Player/index.js
@@ -190,16 +190,22 @@ class Player extends React.Component {
             }
           </div>
           <div className="player-content-action">
-            <a data-tip data-for="global">
+            <a data-tip="Song URL Copied!" data-for="copy">
               <Clipboard component="span" data-clipboard-text={track.permalink_url}>
-                  <div className="player-content-link">
-                    <i className="fa fa-share" />
-                  </div>
+                <div className="player-content-link">
+                  <i className="fa fa-share" />
+                </div>
               </Clipboard>
             </a>
-            <ReactTooltip id="global" event="click" aria-haspopup="true">
-              <p>Song URL copied!</p>
-            </ReactTooltip>
+            <ReactTooltip
+              delayHide={3000}
+              id="copy"
+              event="click"
+              eventOff="mousemove"
+              aria-haspopup="true"
+              effect="solid"
+              offset={{ right: 25 }}
+            />
           </div>
           <audio id="audio" ref="audio" src={addTempClientIdWith(stream_url, '?')}></audio>
         </div>

--- a/src/components/Player/index.js
+++ b/src/components/Player/index.js
@@ -191,7 +191,7 @@ class Player extends React.Component {
           </div>
           <div className="player-content-action">
             <a data-tip data-for="global">
-              <Clipboard component="a" data-clipboard-text={track.permalink_url}>
+              <Clipboard component="span" data-clipboard-text={track.permalink_url}>
                   <div className="player-content-link">
                     <i className="fa fa-share" />
                   </div>


### PR DESCRIPTION
1. Making the effect solid and giving it an offset would make the tooltip always display on top of the share button instead of where the user clicked.

2. As for the hiding after a certain seconds part, at first, I tried to do the hiding in onClick of `<a data-tip="Song URL Copied!" data-for="copy" onClick={...}>`',  but the onClick is not firing.. : (
An alternative way would be setting eventOff="mousemove" and delayHide={3000} to trigger the hiding logic whenever the user move the mouse. So until someone come up with why the onClick is not being triggered, this solution should be fine.