### PR TITLE
Fixed issue #57 and refined logic of clearing playlist

### DIFF
--- a/src/actions/player/index.js
+++ b/src/actions/player/index.js
@@ -61,6 +61,7 @@ export function setTrackVolume(volume) {
 export const clearPlaylist = () => (dispatch) => {
   dispatch(emptyPlaylist());
   dispatch(deactivateTrack());
+  dispatch(togglePlayTrack(false));
   dispatch(resetToggle(toggleTypes.PLAYLIST));
   dispatch(resetToggle(toggleTypes.VOLUME));
 };
@@ -181,7 +182,9 @@ export const removeTrackFromPlaylist = (track) => (dispatch, getState) => {
   const playlistSize = getState().player.playlist.length;
   if (playlistSize < 2) {
     dispatch(deactivateTrack());
+    dispatch(togglePlayTrack(false));
     dispatch(resetToggle(toggleTypes.PLAYLIST));
+    dispatch(resetToggle(toggleTypes.VOLUME));
   }
 
   dispatch(removeFromPlaylist(track.id));


### PR DESCRIPTION
When we clear the play queue, we need to 1. Set current playing track to null in the store. 2. Set isPlaying to false. 3. Toggle off the playlist. 4. Toggle off the volume bar.