### PR TITLE
Fix issue #64: dashboard title text not being fully displayed

### DIFF
--- a/src/components/Permalink/index.js
+++ b/src/components/Permalink/index.js
@@ -4,7 +4,7 @@ import React from 'react';
 function Permalink({ link, text, title }) {
   return (
     <a href={link} title={title}>
-      {text}
+      <span>{text}</span>
     </a>
   );
 }

--- a/styles/components/item.scss
+++ b/styles/components/item.scss
@@ -19,6 +19,9 @@
     a {
       overflow: hidden;
       height: 14px;
+      span {
+        line-height: 14px;
+      }
     }
 
   }


### PR DESCRIPTION
I fixed the issue by wrapping the text of the anchor with a span and gave it a line-height of 14px. However, do you think we should split the artist and track title into two separate lines other than fitting them into a single line as in the current version the title is being not fully displayed? Or we could give it a tooltip or title for the user to know the hidden part of the title?