### PR TITLE
Bug fix for dashboard redirect and add new test for session reducer

### DIFF
--- a/src/actions/session/index.js
+++ b/src/actions/session/index.js
@@ -20,7 +20,7 @@ function setUser(user) {
   };
 }
 
-function setLoginError(error) {
+export function setLoginError(error) {
   return {
     type: actionTypes.SET_LOGIN_ERROR,
     error

--- a/src/components/Dashboard/index.js
+++ b/src/components/Dashboard/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Redirect } from 'react-router-dom';
 import { connect } from 'react-redux';
-import { resetSession } from '../../actions/session';
+import { setLoginError } from '../../actions/session';
 import * as requestTypes from '../../constants/requestTypes';
 import StreamActivities from '../../components/StreamActivities';
 import FollowersList from '../../components/FollowersList';
@@ -10,7 +10,9 @@ import FavoritesList from '../../components/FavoritesList';
 
 class Dashboard extends React.Component {
   componentWillUnmount() {
-    this.props.resetSession();
+    if (this.props.loginError) {
+      this.props.setLoginError(null);
+    }
   }
 
   render() {
@@ -44,4 +46,4 @@ const mapStateToProps = state => ({
   loginError: state.session.loginError,
 });
 
-export default connect(mapStateToProps, { resetSession })(Dashboard);
+export default connect(mapStateToProps, { setLoginError })(Dashboard);

--- a/src/reducers/session/spec.js
+++ b/src/reducers/session/spec.js
@@ -12,12 +12,14 @@ describe('session reducer', () => {
 
       const previousState = {
         user: 'foo',
-        session: 'bar'
+        session: 'bar',
+        loginError: 'access_denied'
       };
 
       const expectedState = {
         user: null,
-        session: null
+        session: null,
+        loginError: null
       };
 
       expect(session(previousState, action)).to.eql(expectedState);
@@ -64,6 +66,31 @@ describe('session reducer', () => {
       const expectedState = {
         user: 'shuar',
         session: 'bar'
+      };
+
+      expect(session(previousState, action)).to.eql(expectedState);
+    });
+
+  });
+
+  describe('SET_LOGIN_ERROR', () => {
+
+    it('sets a login error', () => {
+      const action = {
+        type: actionTypes.SET_LOGIN_ERROR,
+        error: 'access_denied'
+      };
+
+      const previousState = {
+        user: 'foo',
+        session: 'bar',
+        loginError: null,
+      };
+
+      const expectedState = {
+        user: 'foo',
+        session: 'bar',
+        loginError: 'access_denied'
       };
 
       expect(session(previousState, action)).to.eql(expectedState);


### PR DESCRIPTION
1. Reset login error when leaving the dashboard page instead of resetting the whole session.
2. Add test for newly added functions for session reducer.