### PR TITLE
Remove loginError from state

### DIFF
--- a/src/actions/session/index.js
+++ b/src/actions/session/index.js
@@ -20,13 +20,6 @@ function setUser(user) {
   };
 }
 
-export function setLoginError(error) {
-  return {
-    type: actionTypes.SET_LOGIN_ERROR,
-    error
-  };
-}
-
 export function resetSession() {
   return {
     type: actionTypes.RESET_SESSION
@@ -55,8 +48,7 @@ export const login = () => (dispatch) => {
     dispatch(setSession(session));
     dispatch(fetchUser());
     dispatch(setRequestInProcess(false, requestTypes.AUTH));
-  }).catch((err) => {
-    dispatch(setLoginError(err));
+  }).catch(() => {
     dispatch(setRequestInProcess(false, requestTypes.AUTH));
   });
 };

--- a/src/components/Dashboard/index.js
+++ b/src/components/Dashboard/index.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import { Redirect } from 'react-router-dom';
 import { connect } from 'react-redux';
-import { setLoginError } from '../../actions/session';
 import * as requestTypes from '../../constants/requestTypes';
 import StreamActivities from '../../components/StreamActivities';
 import FollowersList from '../../components/FollowersList';
@@ -9,20 +8,15 @@ import FollowingsList from '../../components/FollowingsList';
 import FavoritesList from '../../components/FavoritesList';
 
 class Dashboard extends React.Component {
-  componentWillUnmount() {
-    if (this.props.loginError) {
-      this.props.setLoginError(null);
-    }
-  }
-
   render() {
-    const { isAuthInProgress, isAuthed, loginError } = this.props;
-    if ((!isAuthInProgress && !isAuthed) || loginError) {
-      return <Redirect to="/" />;
-    }
+    const { isAuthInProgress, isAuthed } = this.props;
 
     if (isAuthInProgress) {
       return null;
+    }
+
+    if (!isAuthed) {
+      return <Redirect to="/" />;
     }
 
     return (
@@ -41,9 +35,8 @@ class Dashboard extends React.Component {
 }
 
 const mapStateToProps = state => ({
-  isAuthed: state.session.session,
+  isAuthed: Boolean(state.session.session),
   isAuthInProgress: state.request[requestTypes.AUTH],
-  loginError: state.session.loginError,
 });
 
-export default connect(mapStateToProps, { setLoginError })(Dashboard);
+export default connect(mapStateToProps)(Dashboard);

--- a/src/constants/actionTypes.js
+++ b/src/constants/actionTypes.js
@@ -1,6 +1,5 @@
 export const SET_SESSION = 'SET_SESSION';
 export const SET_USER = 'SET_USER';
-export const SET_LOGIN_ERROR = 'SET_LOGIN_ERROR';
 export const RESET_SESSION = 'RESET_SESSION';
 
 export const MERGE_ENTITIES = 'MERGE_ENTITIES';

--- a/src/reducers/session/index.js
+++ b/src/reducers/session/index.js
@@ -3,7 +3,6 @@ import * as actionTypes from '../../constants/actionTypes';
 const initialState = {
   session: null,
   user: null,
-  loginError: null
 };
 
 export default function(state = initialState, action) {
@@ -12,8 +11,6 @@ export default function(state = initialState, action) {
       return setSession(state, action.session);
     case actionTypes.SET_USER:
       return setUser(state, action.user);
-    case actionTypes.SET_LOGIN_ERROR:
-      return setLoginError(state, action.error);
     case actionTypes.RESET_SESSION:
       return initialState;
   }
@@ -26,8 +23,4 @@ function setSession(state, session) {
 
 function setUser(state, user) {
   return { ...state, user };
-}
-
-function setLoginError(state, error) {
-  return { ...state, loginError: error };
 }

--- a/src/reducers/session/spec.js
+++ b/src/reducers/session/spec.js
@@ -73,29 +73,4 @@ describe('session reducer', () => {
 
   });
 
-  describe('SET_LOGIN_ERROR', () => {
-
-    it('sets a login error', () => {
-      const action = {
-        type: actionTypes.SET_LOGIN_ERROR,
-        error: 'access_denied'
-      };
-
-      const previousState = {
-        user: 'foo',
-        session: 'bar',
-        loginError: null,
-      };
-
-      const expectedState = {
-        user: 'foo',
-        session: 'bar',
-        loginError: 'access_denied'
-      };
-
-      expect(session(previousState, action)).to.eql(expectedState);
-    });
-
-  });
-
 });


### PR DESCRIPTION
I just realized that 'loginError' does not have to be in the state since we do not need to show it anywhere in the UI, so I think it should be removed to keep the code clean.