### PR TITLE
Add source map to make debugging easier

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -50,5 +50,6 @@ module.exports = {
         'NODE_ENV': '"development"'
       }
     })
-  ]
+  ],
+  devtool: 'source-map'
 };


### PR DESCRIPTION
By turning on the devtool in webpack it'll take us right to the source code instead of showing something like bundle.js: 45602.