### PR TITLE
Replaced the hyphen literal in track content with the HTML entity of …

### DIFF
--- a/src/components/Track/stream.js
+++ b/src/components/Track/stream.js
@@ -115,7 +115,8 @@ function TrackStream({
           <div>
             <TrackIcon trackCount={typeTracks[activity.id]} />
             <RepostIcon repostCount={typeReposts[activity.id]} />
-            <Permalink link={userEntity.permalink_url} text={username} />&nbsp;-&nbsp;
+            <Permalink link={userEntity.permalink_url} text={username}/>
+              &nbsp;&#8209;&nbsp;
             <Permalink link={permalink_url} text={title} />
           </div>
           <div>


### PR DESCRIPTION
…a hyphen'

References: #106

The strange characters appear in Chrome and Firefox as well. The issue is there was an actual hyphen included in the code. I updated it to an HTML entity with the spaces entities and it cleared up the issue. 

https://www.w3schools.com/html/html_entities.asp