### PR TITLE
Open permalink in a new tab

### DIFF
--- a/src/components/Permalink/index.js
+++ b/src/components/Permalink/index.js
@@ -1,9 +1,11 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-function Permalink({ link, text, title }) {
+function Permalink({ link, text, title, openInNewTab }) {
+  const additionalAttributes = (openInNewTab) ? { target: '_blank', rel: 'noopener' } : {};
+
   return (
-    <a href={link} title={title}>
+    <a href={link} title={title} {...additionalAttributes}>
       <span>{text}</span>
     </a>
   );
@@ -12,7 +14,8 @@ function Permalink({ link, text, title }) {
 Permalink.propTypes = {
   link: PropTypes.string,
   text: PropTypes.string,
-  title: PropTypes.string
+  title: PropTypes.string,
+  openInNewTab: PropTypes.bool
 };
 
 export default Permalink;

--- a/src/components/Track/stream.js
+++ b/src/components/Track/stream.js
@@ -115,9 +115,9 @@ function TrackStream({
           <div>
             <TrackIcon trackCount={typeTracks[activity.id]} />
             <RepostIcon repostCount={typeReposts[activity.id]} />
-            <Permalink link={userEntity.permalink_url} text={username}/>
+            <Permalink link={userEntity.permalink_url} text={username} openInNewTab />
               &nbsp;&#8209;&nbsp;
-            <Permalink link={permalink_url} text={title} />
+            <Permalink link={permalink_url} text={title} openInNewTab />
           </div>
           <div>
             <Duration


### PR DESCRIPTION
Hi,

I've added functionality for opening permalinks in a new tab. When clicking on an artists name or SoundCloud track title, a new tab will open (#86).